### PR TITLE
Stop hardcoding the default port for ssh

### DIFF
--- a/cmd/sshocker/run.go
+++ b/cmd/sshocker/run.go
@@ -53,7 +53,7 @@ var (
 func parseHost(s string) (string, int, error) {
 	if !strings.Contains(s, ":") {
 		// FIXME: this check is not valid for IPv6!
-		return s, 22, nil
+		return s, 0, nil
 	}
 	host, portStr, err := net.SplitHostPort(s)
 	if err != nil {

--- a/pkg/reversesshfs/reversesshfs.go
+++ b/pkg/reversesshfs/reversesshfs.go
@@ -33,7 +33,11 @@ func (rsf *ReverseSSHFS) Prepare() error {
 	if !filepath.IsAbs(rsf.RemotePath) {
 		return errors.Errorf("unexpected relative path: %q", rsf.RemotePath)
 	}
-	sshArgs = append(sshArgs, "-p", strconv.Itoa(rsf.Port), rsf.Host, "--", "mkdir", "-p", rsf.RemotePath)
+	if rsf.Port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(rsf.Port))
+	}
+	sshArgs = append(sshArgs, rsf.Host, "--")
+	sshArgs = append(sshArgs, "mkdir", "-p", rsf.RemotePath)
 	sshCmd := exec.Command(sshBinary, sshArgs...)
 	logrus.Debugf("executing ssh for preparing sshfs: %s %v", sshCmd.Path, sshCmd.Args)
 	out, err := sshCmd.CombinedOutput()
@@ -52,7 +56,11 @@ func (rsf *ReverseSSHFS) Start() error {
 	if !filepath.IsAbs(rsf.RemotePath) {
 		return errors.Errorf("unexpected relative path: %q", rsf.RemotePath)
 	}
-	sshArgs = append(sshArgs, "-p", strconv.Itoa(rsf.Port), rsf.Host, "--", "sshfs", ":"+rsf.LocalPath, rsf.RemotePath, "-o", "slave")
+	if rsf.Port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(rsf.Port))
+	}
+	sshArgs = append(sshArgs, rsf.Host, "--")
+	sshArgs = append(sshArgs, "sshfs", ":"+rsf.LocalPath, rsf.RemotePath, "-o", "slave")
 	if rsf.Readonly {
 		sshArgs = append(sshArgs, "-o", "ro")
 	}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -45,7 +45,11 @@ func ExitMaster(host string, port int, c *SSHConfig) error {
 		return errors.New("got nil SSHConfig")
 	}
 	args := c.Args()
-	args = append(args, "-O", "exit", "-p", strconv.Itoa(port), host)
+	args = append(args, "-O", "exit")
+	if port != 0 {
+		args = append(args, "-p", strconv.Itoa(port))
+	}
+	args = append(args, host)
 	cmd := exec.Command(c.Binary(), args...)
 	logrus.Debugf("executing ssh for exiting the master: %s %v", cmd.Path, cmd.Args)
 	out, err := cmd.CombinedOutput()
@@ -90,7 +94,10 @@ func ExecuteScript(host string, port int, c *SSHConfig, script, scriptName strin
 	}
 	sshBinary := c.Binary()
 	sshArgs := c.Args()
-	sshArgs = append(sshArgs, "-p", strconv.Itoa(port), host, "--", interpreter)
+	if port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(port))
+	}
+	sshArgs = append(sshArgs, host, "--", interpreter)
 	sshCmd := exec.Command(sshBinary, sshArgs...)
 	sshCmd.Stdin = strings.NewReader(script)
 	var stderr bytes.Buffer

--- a/pkg/sshocker/sshocker.go
+++ b/pkg/sshocker/sshocker.go
@@ -31,7 +31,10 @@ func (x *Sshocker) Run() error {
 	for _, l := range x.LForwards {
 		args = append(args, "-L", l)
 	}
-	args = append(args, "-p", strconv.Itoa(x.Port), x.Host, "--")
+	if x.Port != 0 {
+		args = append(args, "-p", strconv.Itoa(x.Port))
+	}
+	args = append(args, x.Host, "--")
 	if len(x.Command) > 0 {
 		args = append(args, x.Command...)
 	}


### PR DESCRIPTION
In case the `Port` is given in the ssh config already...

The ssh command will know the default port, otherwise.

----

This makes it work for accessing podman machine VMs

```
Host podman-machine-default
    IdentityFile /home/anders/.ssh/podman-machine-default
    User core
    Hostname localhost
    Port 37719
    UserKnownHostsFile /dev/null
    StrictHostKeyChecking no
```


Closes #21