### PR TITLE
Use OpenSSH SFTP Server instead of github.com/pkg/sftp (when available)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ SSH flags:
 * `-F`, `--ssh-config=FILE`: specify SSH config file used for `ssh -F`
 * `--ssh-persist=(true|false)` (default: `true`): enable ControlPersist
 
+SSHFS flags:
+* `--sshfs-noempty` (default: `false`): enable sshfs nonempty
+
+SFTP server flags:
+* `--driver=DRIVER` (default: `auto`): SFTP server driver. `builtin` (legacy) or `openssh-sftp-server` (robust and secure, recommended).
+   `openssh-sftp-server` is chosen by default when the OpenSSH SFTP Server binary is detected.
+* `--openssh-sftp-server=BINARY`: OpenSSH SFTP Server binary.
+   Automatically detected when installed in well-known locations such as `/usr/libexec/sftp-server`.
+
 ### Subcommand: `help`
 Shows help
 

--- a/cmd/sshocker/run.go
+++ b/cmd/sshocker/run.go
@@ -42,6 +42,16 @@ var (
 			Usage: "enable sshfs nonempty",
 			Value: false,
 		},
+		&cli.StringFlag{
+			Name:  "driver",
+			Usage: "SFTP server driver. \"builtin\" (legacy) or \"openssh-sftp-server\" (robust and secure, recommended), automatically chosen by default",
+			Value: "auto",
+		},
+		&cli.StringFlag{
+			Name:  "openssh-sftp-server",
+			Usage: "OpenSSH SFTP Server binary, automatically chosen by default",
+			Value: "",
+		},
 	}
 	runCommand = &cli.Command{
 		Name:   "run",
@@ -85,11 +95,13 @@ func runAction(clicontext *cli.Context) error {
 		sshfsAdditionalArgs = append(sshfsAdditionalArgs, "-o", "nonempty")
 	}
 	x := &sshocker.Sshocker{
-		SSHConfig:           sshConfig,
-		Host:                host,
-		Port:                port,
-		Command:             clicontext.Args().Tail(),
-		SSHFSAdditionalArgs: sshfsAdditionalArgs,
+		SSHConfig:               sshConfig,
+		Host:                    host,
+		Port:                    port,
+		Command:                 clicontext.Args().Tail(),
+		SSHFSAdditionalArgs:     sshfsAdditionalArgs,
+		Driver:                  clicontext.String("driver"),
+		OpensshSftpServerBinary: clicontext.String("openssh-sftp-server"),
 	}
 	if len(x.Command) > 0 && x.Command[0] == "--" {
 		x.Command = x.Command[1:]

--- a/pkg/sshocker/sshocker.go
+++ b/pkg/sshocker/sshocker.go
@@ -15,12 +15,14 @@ import (
 
 type Sshocker struct {
 	*ssh.SSHConfig
-	Host                string   // Required
-	Port                int      // Required
-	Command             []string // Optional
-	Mounts              []mount.Mount
-	LForwards           []string
-	SSHFSAdditionalArgs []string
+	Host                    string   // Required
+	Port                    int      // Required
+	Command                 []string // Optional
+	Mounts                  []mount.Mount
+	LForwards               []string
+	SSHFSAdditionalArgs     []string
+	Driver                  reversesshfs.Driver
+	OpensshSftpServerBinary string
 }
 
 func (x *Sshocker) Run() error {
@@ -48,13 +50,15 @@ func (x *Sshocker) Run() error {
 		switch m.Type {
 		case mount.MountTypeReverseSSHFS:
 			rsf := &reversesshfs.ReverseSSHFS{
-				SSHConfig:           x.SSHConfig,
-				LocalPath:           m.Source,
-				Host:                x.Host,
-				Port:                x.Port,
-				RemotePath:          m.Destination,
-				Readonly:            m.Readonly,
-				SSHFSAdditionalArgs: x.SSHFSAdditionalArgs,
+				Driver:                  x.Driver,
+				OpensshSftpServerBinary: x.OpensshSftpServerBinary,
+				SSHConfig:               x.SSHConfig,
+				LocalPath:               m.Source,
+				Host:                    x.Host,
+				Port:                    x.Port,
+				RemotePath:              m.Destination,
+				Readonly:                m.Readonly,
+				SSHFSAdditionalArgs:     x.SSHFSAdditionalArgs,
 			}
 			if err := rsf.Prepare(); err != nil {
 				return fmt.Errorf("failed to prepare mounting %q (local) onto %q (remote): %w", rsf.LocalPath, rsf.RemotePath, err)


### PR DESCRIPTION
The OpenSSH SFTP Server Driver (`--driver=openssh-sftp-server`) might be more robust and secure than the legacy builtin driver (`--driver=builtin`).

No performance benefit though.

The OpenSSH SFTP Server Driver is used by default when `sftp-server` binary is installed on the host.
(Installed by default on macOS)
