### PR TITLE
Don't use filepath for remote paths only for local

### DIFF
--- a/pkg/reversesshfs/reversesshfs.go
+++ b/pkg/reversesshfs/reversesshfs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -43,7 +44,7 @@ type ReverseSSHFS struct {
 func (rsf *ReverseSSHFS) Prepare() error {
 	sshBinary := rsf.SSHConfig.Binary()
 	sshArgs := rsf.SSHConfig.Args()
-	if !filepath.IsAbs(rsf.RemotePath) {
+	if !path.IsAbs(rsf.RemotePath) {
 		return fmt.Errorf("unexpected relative path: %q", rsf.RemotePath)
 	}
 	if rsf.Port != 0 {
@@ -115,7 +116,7 @@ func (rsf *ReverseSSHFS) Start() error {
 	if !filepath.IsAbs(rsf.LocalPath) {
 		return fmt.Errorf("unexpected relative path: %q", rsf.LocalPath)
 	}
-	if !filepath.IsAbs(rsf.RemotePath) {
+	if !path.IsAbs(rsf.RemotePath) {
 		return fmt.Errorf("unexpected relative path: %q", rsf.RemotePath)
 	}
 	if rsf.Port != 0 {


### PR DESCRIPTION
The remote paths are on a Linux system, and need "path".

The local paths can be different, handled by "filepath".

Example:

	Local: "C:\\msys64\\tmp\\lima"

	Remote: "/tmp/lima"

----

Error:

`failed to mount reverse sshfs for "/tmp/lima" on "/tmp/lima": unexpected relative path: "/tmp/lima"`