### PR TITLE
Add openssh sftp-server path detection for windows

### DIFF
--- a/pkg/reversesshfs/reversesshfs.go
+++ b/pkg/reversesshfs/reversesshfs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -77,6 +78,17 @@ func DetectOpensshSftpServerBinary() string {
 		sftpServer := filepath.Join(local, "libexec", "sftp-server")
 		if exe, err := exec.LookPath(sftpServer); err == nil {
 			return exe
+		}
+	}
+	if runtime.GOOS == "windows" {
+		// unix path is like "/usr/lib/ssh/sftp-server"
+		cygpathCmd := exec.Command("cygpath", "-w", "/usr/lib/ssh/sftp-server")
+		// windows path is like `C:\msys64\usr\lib\ssh\sftp-server.exe`
+		if out, err := cygpathCmd.Output(); err == nil {
+			sftpServer := strings.TrimSpace(string(out))
+			if exe, err := exec.LookPath(sftpServer); err == nil {
+				return exe
+			}
 		}
 	}
 	candidates := []string{


### PR DESCRIPTION
Unfortunately LookPath doesn't handle DOS extensions.

But it was already confused by the `/` location anyway.

i.e.  `LookPath("/usr/lib/openssh/sftp-server")` fails

Even though the Windows program works fine to execute.

----

Testing on Ubuntu:

```console
$ export WINEPATH="C:\\Program Files\\qemu;C:\\Program Files\\Git\\usr\\bin"
$ wine cygpath -w /usr/lib/ssh/sftp-server | cat
Cygwin WARNING:
  Couldn't compute FAST_CWD pointer.  This typically occurs if you're using
  an older Cygwin version on a newer Windows.  Please update to the latest
  available Cygwin version from https://cygwin.com/.  If the problem persists,
  please see https://cygwin.com/problems.html

C:\Program Files\Git\usr\lib\ssh\sftp-server.exe
```

Spaces and carriage returns, oh my.

I had first installed [Git for Windows](https://git-scm.com/download/win)