### PR TITLE
Add ability to pass arbitrary -o options to sshfs call

### DIFF
--- a/cmd/sshocker/run.go
+++ b/cmd/sshocker/run.go
@@ -42,6 +42,10 @@ var (
 			Usage: "enable sshfs nonempty",
 			Value: false,
 		},
+		&cli.StringSliceFlag{
+			Name:  "sshfs-option",
+			Usage: "Set sshfs mount options.",
+		},
 		&cli.StringFlag{
 			Name:  "driver",
 			Usage: "SFTP server driver. \"builtin\" (legacy) or \"openssh-sftp-server\" (robust and secure, recommended), automatically chosen by default",
@@ -94,6 +98,10 @@ func runAction(clicontext *cli.Context) error {
 	if clicontext.Bool("sshfs-nonempty") {
 		sshfsAdditionalArgs = append(sshfsAdditionalArgs, "-o", "nonempty")
 	}
+	for _, o := range clicontext.StringSlice("sshfs-option") {
+		sshfsAdditionalArgs = append(sshfsAdditionalArgs, "-o", o)
+	}
+
 	x := &sshocker.Sshocker{
 		SSHConfig:               sshConfig,
 		Host:                    host,


### PR DESCRIPTION
This adds a generic option to pass arbitrary `-o` options to the sshfs call, which allows more flexibility beyond just passing in the `idmap` flag. E.g., I am using the following to allow bind mounting from local to remote docker host:

```
sshocker \
  --sshfs-option allow_other \
  --sshfs-option 'idmap=file' \
  --sshfs-option 'uidfile=/home/remoteuser/.sshocker/uidmap' \
  --sshfs-option 'gidfile=/home/remoteuser/.sshocker/gidmap' \
  # ... other args omitted for brevity ...
```

Related: https://github.com/lima-vm/sshocker/pull/31