### PR TITLE
Accepting absolute Unix paths on Windows for use in Cygwin/msys2

### DIFF
--- a/pkg/reversesshfs/reversesshfs.go
+++ b/pkg/reversesshfs/reversesshfs.go
@@ -125,8 +125,11 @@ func DetectDriver(explicitOpensshSftpServerBinary string) (Driver, string, error
 func (rsf *ReverseSSHFS) Start() error {
 	sshBinary := rsf.SSHConfig.Binary()
 	sshArgs := rsf.SSHConfig.Args()
-	if !filepath.IsAbs(rsf.LocalPath) {
+	if !filepath.IsAbs(rsf.LocalPath) && !path.IsAbs(rsf.LocalPath) {
 		return fmt.Errorf("unexpected relative path: %q", rsf.LocalPath)
+	}
+	if runtime.GOOS == "windows" && path.IsAbs(rsf.LocalPath) {
+		logrus.Infof("Accepting %q Unix path, assuming Cygwin/msys2 OpenSSH", rsf.LocalPath)
 	}
 	if !path.IsAbs(rsf.RemotePath) {
 		return fmt.Errorf("unexpected relative path: %q", rsf.RemotePath)


### PR DESCRIPTION
Cygwin/msys2 ssh/sftp is able to work with cygpaths, which are Unix paths used within Cygwin/msys2 ecosystems.

Also, I have some doubts that `sshfs` [here](https://github.com/arixmkii/sshocker/blob/3d8ea8cc9dee2f8f53b8c3c5063107508b73a7d6/pkg/reversesshfs/reversesshfs.go#L141) ever supported Windows paths 😅 

Needed for reverse-sshfs for Lima machine on Windows with msys2/Cygwin OpenSSH https://github.com/lima-vm/lima/issues/909 