### PR TITLE
Add support for using sftp-server found within PATH

### DIFF
--- a/pkg/reversesshfs/reversesshfs.go
+++ b/pkg/reversesshfs/reversesshfs.go
@@ -63,6 +63,9 @@ func (rsf *ReverseSSHFS) Prepare() error {
 }
 
 func DetectOpensshSftpServerBinary() string {
+	if exe, err := exec.LookPath("sftp-server"); err == nil {
+		return exe
+	}
 	homebrewSSHD := []string{
 		"/usr/local/sbin/sshd",
 		"/opt/homebrew/sbin/sshd",


### PR DESCRIPTION
Closes https://github.com/lima-vm/lima/pull/3183

Before trying list of well-known candidates allow detection routine to check if the binary is discoverable inside PATH already. This covers cases for unknown distributions or user built packages, which could be symlinked into `/usr/local/bin` to be discoverable before system packages and Windows, where needed dependencies might have different packaging.

Tested on Windows machine with my work in progress QEMU support branch of Lima.