### PR TITLE
Make argument quotation compatible with cygwin/msys2/gitbash on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x, 1.24.x]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4
@@ -20,5 +20,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - run: make
-    - run: sudo make install
+    - if: "${{ matrix.platform != 'windows-latest' }}"
+      run: sudo make install
     - run: go test -covermode=atomic -race -v ./...

--- a/pkg/reversesshfs/reversesshfs_test.go
+++ b/pkg/reversesshfs/reversesshfs_test.go
@@ -1,0 +1,35 @@
+package reversesshfs
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestAddQuotes(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected string
+	}
+	var testCases []testCase
+	if runtime.GOOS != "windows" {
+		testCases = []testCase{
+			{
+				input:    "/user/test/path",
+				expected: "\"/user/test/path\"",
+			},
+		}
+	} else {
+		testCases = []testCase{
+			{
+				input:    "/user/test/path",
+				expected: "'/user/test/path'",
+			},
+		}
+	}
+	for i, tc := range testCases {
+		got := addQuotes(tc.input)
+		if got != tc.expected {
+			t.Errorf("#%d: expected %q, got %q", i, tc.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
It is the same situation like in https://github.com/lima-vm/lima/blob/786c1f5f3c6e8ff276c0c5d6789cdd9243d70f49/pkg/sshutil/sshutil.go#L271

Windows based tooling can't correctly escape `"`. 

The implemented workaround probably will not work for some extreme cases, but at least it is not failing outright from the start. 

It has been tested to work on Windows with Git Bash and WSL2 based tooling.